### PR TITLE
Add webcam enable translation

### DIFF
--- a/guacamole/src/main/frontend/src/translations/ca.json
+++ b/guacamole/src/main/frontend/src/translations/ca.json
@@ -497,6 +497,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Nom de la unitat:",
         "FIELD_HEADER_DRIVE_PATH"       : "Ruta de la unitat:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Habilita l'entrada d'àudio (micròfon):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Habilita la webcam:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Habilita la composició d'escriptori (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Habilita la unitat:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Habilita el suavització de tipus de lletra (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/cs.json
+++ b/guacamole/src/main/frontend/src/translations/cs.json
@@ -574,6 +574,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Název jednotky:",
         "FIELD_HEADER_DRIVE_PATH"       : "Cesta na disku:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Povolit zvukový vstup (mikrofon):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Povolit webkameru:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Povolit kompozici pracovní plochy (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Povolit jednotku:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Povolit vyhlazení písma (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/de.json
+++ b/guacamole/src/main/frontend/src/translations/de.json
@@ -565,6 +565,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Laufwerksname:",
         "FIELD_HEADER_DRIVE_PATH"       : "Laufwerkspfad:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Audioeingänge (Mikrofon) aktivieren:",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Webcam aktivieren:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Desktop Gestaltung (Aero) aktivieren:",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Austauschlaufwerk aktivieren:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Schriftartglättung (ClearType) aktivieren:",

--- a/guacamole/src/main/frontend/src/translations/en.json
+++ b/guacamole/src/main/frontend/src/translations/en.json
@@ -601,6 +601,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Drive name:",
         "FIELD_HEADER_DRIVE_PATH"       : "Drive path:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Enable audio input (microphone):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Enable webcam:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Enable desktop composition (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Enable drive:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Enable font smoothing (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/es.json
+++ b/guacamole/src/main/frontend/src/translations/es.json
@@ -471,6 +471,7 @@
         "FIELD_HEADER_DRIVE_NAME"        : "Unidad:",
         "FIELD_HEADER_DRIVE_PATH"        : "Ruta Unidad:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Activar entrada de audio (Microfono):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Activar cámara web:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Activar composición de escritorio (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Activar unidad:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Activar suavizado de fuente (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/fr.json
+++ b/guacamole/src/main/frontend/src/translations/fr.json
@@ -589,6 +589,7 @@
         "FIELD_HEADER_DRIVE_NAME"      : "Nom du lecteur:",
         "FIELD_HEADER_DRIVE_PATH"      : "Chemin du lecteur:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Activer l'entrée audio (microphone):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Activer la webcam:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Activer la composition du bureau (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"    : "Activer lecteur réseau:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING" : "Activer le lissage des polices (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/it.json
+++ b/guacamole/src/main/frontend/src/translations/it.json
@@ -280,6 +280,7 @@
         "FIELD_HEADER_DOMAIN"          : "Dominio:",
         "FIELD_HEADER_DPI"             : "Risoluzione (DPI):",
         "FIELD_HEADER_DRIVE_PATH"      : "Drive path:",
+        "FIELD_HEADER_ENABLE_WEBCAM"   : "Abilita webcam:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Abilita composizione desktop (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Abilita drive:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Abilita l'arrotondamento dei caratteri (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/ja.json
+++ b/guacamole/src/main/frontend/src/translations/ja.json
@@ -425,6 +425,7 @@
         "FIELD_HEADER_DRIVE_NAME"      : "ドライブ名:",
         "FIELD_HEADER_DRIVE_PATH"      : "ドライブパス:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "入力オーディオ（マイク）の有効化:",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "ウェブカメラを有効化:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "デスクトップコンポジション(Aero)の有効化:",
         "FIELD_HEADER_ENABLE_DRIVE"               : "ドライブの有効化:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "クリアタイプフォントの有効化:",

--- a/guacamole/src/main/frontend/src/translations/ko.json
+++ b/guacamole/src/main/frontend/src/translations/ko.json
@@ -464,6 +464,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "드라이브 이름:",
         "FIELD_HEADER_DRIVE_PATH"       : "드라이브 주소:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "오디오 입력 활성화 (마이크):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "웹캠 사용:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "바탕화면 구성 활성화 (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "드라이브 활성화:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "글꼴 다듬기 활성화 (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/nl.json
+++ b/guacamole/src/main/frontend/src/translations/nl.json
@@ -296,6 +296,7 @@
         "FIELD_HEADER_DOMAIN"          : "Domein:",
         "FIELD_HEADER_DPI"             : "Resolutie (DPI):",
         "FIELD_HEADER_DRIVE_PATH"      : "Station map:",
+        "FIELD_HEADER_ENABLE_WEBCAM"   : "Webcam inschakelen:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Inschakelen bureaublad compositie (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"    : "Inschakelen station:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Inschakelen font smoothing (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/no.json
+++ b/guacamole/src/main/frontend/src/translations/no.json
@@ -280,6 +280,7 @@
         "FIELD_HEADER_DOMAIN"          : "Domene:",
         "FIELD_HEADER_DPI"             : "Oppløsning (DPI):",
         "FIELD_HEADER_DRIVE_PATH"      : "Sti til disk:",
+        "FIELD_HEADER_ENABLE_WEBCAM"   : "Aktiver webkamera:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Aktiver skrivebordssammensetning (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Aktiver disk:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Aktiver fontutjevning (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/pl.json
+++ b/guacamole/src/main/frontend/src/translations/pl.json
@@ -491,6 +491,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Nazwa dysku:",
         "FIELD_HEADER_DRIVE_PATH"       : "Ścieżka dysku:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Włącz wejście dźwięku (mikrofon):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Włącz kamerę internetową:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Włącz kompozycje pulpitu (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Włącz dysk:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Włącz wygładzanie czcionek (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/pt.json
+++ b/guacamole/src/main/frontend/src/translations/pt.json
@@ -471,6 +471,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Nome da unidade:",
         "FIELD_HEADER_DRIVE_PATH"       : "Caminho da unidade:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Habilitar entrada de áudio (microfone):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Habilitar webcam:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Habilitar composição do desktop (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Habilitar unidade:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Habilitar suavização de fonte (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/ru.json
+++ b/guacamole/src/main/frontend/src/translations/ru.json
@@ -436,6 +436,7 @@
         "FIELD_HEADER_DRIVE_NAME"                 : "Название диска:",
         "FIELD_HEADER_DRIVE_PATH"                 : "Путь для диска:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Включить звуковой вход (микрофон):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Включить веб-камеру:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Включить композитор рабочего стола (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Включить диск:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Включить сглаживание шрифтов (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/tr.json
+++ b/guacamole/src/main/frontend/src/translations/tr.json
@@ -598,6 +598,7 @@
         "FIELD_HEADER_DRIVE_NAME"       : "Sürücü adı:",
         "FIELD_HEADER_DRIVE_PATH"       : "Sürücü yolu:",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "Ses girişini etkinleştir (mikrofon):",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "Web kamerasını etkinleştir:",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "Masaüstü kompozisyonunu etkinleştir (Aero):",
         "FIELD_HEADER_ENABLE_DRIVE"               : "Sürücüyü etkinleştir:",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "Yazı tipi yumuşatmayı etkinleştir (ClearType):",

--- a/guacamole/src/main/frontend/src/translations/zh.json
+++ b/guacamole/src/main/frontend/src/translations/zh.json
@@ -571,6 +571,7 @@
         "FIELD_HEADER_DRIVE_NAME"      : "驱动器名称：",
         "FIELD_HEADER_DRIVE_PATH"      : "虚拟盘路径：",
         "FIELD_HEADER_ENABLE_AUDIO_INPUT"         : "启用音频输入（话筒）：",
+        "FIELD_HEADER_ENABLE_WEBCAM"              : "启用网络摄像头：",
         "FIELD_HEADER_ENABLE_DESKTOP_COMPOSITION" : "启用桌面合成效果（Aero）：",
         "FIELD_HEADER_ENABLE_DRIVE"               : "启用虚拟驱动器：",
         "FIELD_HEADER_ENABLE_FONT_SMOOTHING"      : "启用字体平滑（ClearType）：",


### PR DESCRIPTION
## Summary
- add `FIELD_HEADER_ENABLE_WEBCAM` translation to English locale
- provide translations for additional locales

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_b_685e2bcacf04832680d134d9913ceea4