### PR TITLE
Add video input parameter

### DIFF
--- a/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
+++ b/guacamole/src/main/frontend/src/app/client/types/ManagedClient.js
@@ -305,6 +305,15 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
     ManagedClient.AUDIO_INPUT_MIMETYPE = 'audio/L16;rate=44100,channels=2';
 
     /**
+     * The mimetype of video data to be sent along the Guacamole connection if
+     * video input is supported.
+     *
+     * @constant
+     * @type String
+     */
+    ManagedClient.VIDEO_INPUT_MIMETYPE = 'video/webm';
+
+    /**
      * Returns a promise which resolves with the string of connection
      * parameters to be passed to the Guacamole client during connection. This
      * string generally contains the desired connection ID, display resolution,
@@ -356,6 +365,9 @@ angular.module('client').factory('ManagedClient', ['$rootScope', '$injector',
         guacVideo.supported.forEach(function(mimetype) {
             connectString += "&GUAC_VIDEO=" + encodeURIComponent(mimetype);
         });
+
+        connectString += "&GUAC_VIDEO_INPUT=" +
+            encodeURIComponent(ManagedClient.VIDEO_INPUT_MIMETYPE);
 
         // Add image mimetypes to connect string
         guacImage.getSupportedMimetypes().then(function supportedMimetypesKnown(mimetypes) {

--- a/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequest.java
+++ b/guacamole/src/main/java/org/apache/guacamole/tunnel/TunnelRequest.java
@@ -88,6 +88,12 @@ public abstract class TunnelRequest {
     public static final String VIDEO_PARAMETER = "GUAC_VIDEO";
 
     /**
+     * The name of the parameter specifying the mimetype that will be used for
+     * video input streaming from the client.
+     */
+    public static final String VIDEO_INPUT_PARAMETER = "GUAC_VIDEO_INPUT";
+
+    /**
      * The name of the parameter specifying one supported image mimetype. This
      * will normally appear multiple times within a single tunnel request -
      * once for each mimetype.
@@ -314,6 +320,18 @@ public abstract class TunnelRequest {
      */
     public List<String> getVideoMimetypes() {
         return getParameterValues(VIDEO_PARAMETER);
+    }
+
+    /**
+     * Returns the mimetype declared for use with video input streaming within
+     * the tunnel request.
+     *
+     * @return
+     *     The mimetype declared for video input streaming, or null if no
+     *     mimetype was specified.
+     */
+    public String getVideoInputMimetype() {
+        return getParameter(VIDEO_INPUT_PARAMETER);
     }
 
     /**


### PR DESCRIPTION
## Summary
- add video input mimetype constant for ManagedClient
- include GUAC_VIDEO_INPUT when building connect string
- parse `GUAC_VIDEO_INPUT` in TunnelRequest

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685e2bd0d3f08326b4b6cc90cfa1ed3e